### PR TITLE
focus_gained() runs checktime even when autoread is false

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -19,9 +19,6 @@ function! s:delayed_checktime()
 endfunction
 
 function! tmux_focus_events#focus_gained()
-  if !&autoread
-    return
-  endif
   if <SID>cursor_in_cmd_line()
     augroup focus_gained_checktime
       au!


### PR DESCRIPTION
Removed the autoread check in the focus_gained() function.
When autoread is off, Vim now prompts to reload the file when focus is gained,
as it does when switching buffers or resuming from suspension.
