### PR TITLE
Check for command line window in addition to command line

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -4,7 +4,7 @@ endif
 let g:autoloaded_tmux_focus_events = 1
 
 function! s:cursor_in_cmd_line()
-  return !empty(getcmdtype())
+  return !empty(getcmdtype()) || !empty(getcmdwintype())
 endfunction
 
 function! s:delayed_checktime()


### PR DESCRIPTION
This fixes the issue mentioned in #3 which I also experienced. Just adds a boolean to make sure it's not inside the command line history window to the existing command line check. Let me know if anything needs changing.