### PR TITLE
Avoid InsertLeave event for insert mode mapping

### DIFF
--- a/plugin/tmux_focus_events.vim
+++ b/plugin/tmux_focus_events.vim
@@ -54,8 +54,8 @@ function! s:restore_focus_events()
   vnoremap <silent> <F24> <Esc>:silent doautocmd <nomodeline> FocusLost %<CR>gv
   vnoremap <silent> <F25> <Esc>:silent doautocmd <nomodeline> FocusGained %<CR>gv
 
-  inoremap <silent> <F24> <C-\><C-O>:silent doautocmd <nomodeline> FocusLost %<CR>
-  inoremap <silent> <F25> <C-\><C-O>:silent doautocmd <nomodeline> FocusGained %<CR>
+  inoremap <silent> <F24> <C-c>:silent doautocmd <nomodeline> FocusLost %<CR>a
+  inoremap <silent> <F25> <C-c>:silent doautocmd <nomodeline> FocusGained %<CR>a
 
   cnoremap <silent> <F24> <C-\>e<SID>do_autocmd('FocusLost')<CR>
   cnoremap <silent> <F25> <C-\>e<SID>do_autocmd('FocusGained')<CR>


### PR DESCRIPTION
I am using lessspace.vim plugin to remove white spaces when I switch to normal mode. Currently switching windows/panes while insert mode triggers InserrtLeave due to inoremap command prefix and it causes white spaces to be removed in insert mode. Prepending ctrl-c in insert mode instead of ctrl-\ + ctrl-o fixes this issue.