### PR TITLE
Retry s:delayed_checktime on 'E523: Not allowed'

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -15,11 +15,15 @@ function! s:delayed_checktime()
   if <SID>cursor_in_cmd_line()
     return
   endif
-  " clearing out 'emergency' events
-  augroup focus_gained_checktime
-    au!
-  augroup END
-  silent checktime
+  try
+    silent checktime
+    " clearing out 'emergency' events, if the checktime succeeded
+    augroup focus_gained_checktime
+      au!
+    augroup END
+  catch /E523/  " Not allowed here: silent checktime
+    " don't clear the augroup, let it fire again when possible
+  endtry
 endfunction
 
 function! tmux_focus_events#focus_gained()

--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -12,9 +12,6 @@ function! s:cursor_in_cmd_line()
 endfunction
 
 function! s:delayed_checktime()
-  if <SID>cursor_in_cmd_line()
-    return
-  endif
   try
     silent checktime
     " clearing out 'emergency' events, if the checktime succeeded


### PR DESCRIPTION
Howdy!

On neovim, when using vim-tmux-focus-events with vim-airline, I've been seeing the error message:
```
  Error detected while processing function <SNR>52_delayed_checktime:
  line    8:
  E523: Not allowed here:   silent checktime
```
After performing the following steps:
1. Open neovim in tmux,
2. Type a command on the command line (e.g. `:asdfasdfasdf`) without
pressing enter,
3. Focus a different window (e.g. click on a Chrome window),
4. Click on the neovim/tmux terminal window again,
5. Press <ESC> to quit the command line.

[asciinema recording](https://asciinema.org/a/240886)

I'm using NVIM v0.4.0, but I've been seeing this message for a while, so it probably affects older versions of neovim as well. Standard vim doesn't seem to be affected.

This seems to occur despite the plugin already checking whether the user is in the command line (e.g. `mode() !=# 'c'` returns true in the affected function, even in calls where the error is thrown).

I tried patching it by silently catching the exception and letting the `focus_gained_checktime` fire a second time, after `mode()` has finished returning a correct value, which fixes the issue on my machine.