### PR TITLE
fix error `E11: Invalid in command-line window; <CR> executes, CTRL-C…

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -19,6 +19,7 @@ function! s:delayed_checktime()
       au!
     augroup END
   catch /E523/  " Not allowed here: silent checktime
+  catch /E11/   " Invalid in command-line window
     " don't clear the augroup, let it fire again when possible
   endtry
 endfunction


### PR DESCRIPTION
This fixes an E11 error when you switch to another pane and back while in the vim command line window (see `q:`).