### PR TITLE
Retry au * * autocmd if in cmd line and it throws E1155

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -24,16 +24,27 @@ function! s:delayed_checktime()
   endtry
 endfunction
 
-function! tmux_focus_events#focus_gained()
-  if !&autoread
-    return
-  endif
-  if <SID>cursor_in_cmd_line()
+function! s:RetryAU(au_timer)
+  try
     augroup focus_gained_checktime
       au!
       " perform checktime ASAP when outside cmd line
       au * * call <SID>delayed_checktime()
     augroup END
+  catch /E1155/
+    let au_timer = timer_start(50, function('s:RetryAU'))
+    " help nvim display screen
+    redraw!
+  endtry
+endfunction
+
+function! tmux_focus_events#focus_gained()
+  if !&autoread
+    return
+  endif
+  if <SID>cursor_in_cmd_line()
+    " rarely, au * * could throw E1155, retry until ok
+    call <SID>RetryAU(0)
   else
     silent checktime
   endif


### PR DESCRIPTION
See issue https://github.com/tmux-plugins/vim-tmux-focus-events/issues/33
Code change discussed with @bruno- 
thx,
-m