### PR TITLE
fix for #33 and adding augroup

### DIFF
--- a/autoload/tmux_focus_events.vim
+++ b/autoload/tmux_focus_events.vim
@@ -32,7 +32,10 @@ function! tmux_focus_events#focus_gained()
     augroup focus_gained_checktime
       au!
       " perform checktime ASAP when outside cmd line
-      au * * call <SID>delayed_checktime()
+	  "This is buggy:
+      "au * * call <SID>delayed_checktime()
+	  "Replacement:
+      au CmdLineLeave * call <SID>delayed_checktime()
     augroup END
   else
     silent checktime

--- a/plugin/tmux_focus_events.vim
+++ b/plugin/tmux_focus_events.vim
@@ -68,12 +68,15 @@ endfunction
 
 call <SID>restore_focus_events()
 
-" When '&term' changes values for '<F24>', '<F25>', '&t_ti' and '&t_te' are
-" reset. Below autocmd restores values for those options.
-au TermChanged * call <SID>restore_focus_events()
+augroup TMUXFOCUS
+	au!
+	" When '&term' changes values for '<F24>', '<F25>', '&t_ti' and '&t_te' are
+	" reset. Below autocmd restores values for those options.
+	au TermChanged * call <SID>restore_focus_events()
 
-" restore vim 'autoread' functionality
-au FocusGained * call tmux_focus_events#focus_gained()
+	" restore vim 'autoread' functionality
+	au FocusGained * call tmux_focus_events#focus_gained()
+augroup end
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Ubuntu 22.04 (LTS) version of vim is 8022121 which doesn't yet have the Focus* event support.
Thus, the plugin is still used in 2024.

[Issue 33](https://github.com/tmux-plugins/vim-tmux-focus-events/issues/33) should be fixed with this.

It's about re-entering the window when in the command line.
The message appears:
```
Error detected while processing function <SNR>58_do_autocmd[3]..FocusGained Autocommands for "*"..function tmux_focus_events#focus_gained:
line    8:
```

It is caused by matching all events with `au * * ...`
Fixed by limiting: `au  CmdLineLeave * ...`

